### PR TITLE
Commit from develop v1.1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ Pull requests and feature suggestions are welcome!
 
 ---
 
+## ⚠️ Upgrading to v1.1.8+
+
+If you're upgrading from a previous version, existing counters **will not inherit** the new statistical capabilities automatically.
+
+To benefit from improved dashboards and long-term statistics:
+
+1. Go to **Settings → Devices & Services → HA Daily Counter → Options**.
+2. Remove each existing counter.
+3. Recreate them using the updated interface.
+
+Counters created after `v1.1.8` will automatically support **history graphs**, **statistics**, and **better data visualizations**.
+
+---
+
 ## 📄 License
 
 MIT License

--- a/custom_components/ha_daily_counter/config_flow.py
+++ b/custom_components/ha_daily_counter/config_flow.py
@@ -4,7 +4,7 @@ from homeassistant.helpers.selector import (
     EntitySelector,
     EntitySelectorConfig,
     TextSelector,
-    TextSelectorConfig
+    TextSelectorConfig,
 )
 from homeassistant.data_entry_flow import FlowResult
 from typing import Any
@@ -45,7 +45,9 @@ class HADailyCounterConfigFlow(config_entries.ConfigFlow, domain="ha_daily_count
             data_schema=config_entries.vol.Schema({
                 config_entries.vol.Required(CONF_NAME): str,
                 config_entries.vol.Required(ATTR_TRIGGER_ENTITY): EntitySelector(
-                    EntitySelectorConfig()
+                    EntitySelectorConfig(
+                        domain=["sensor", "binary_sensor", "input_boolean", "input_number", "input_text"]
+                    )
                 ),
                 config_entries.vol.Required(ATTR_TRIGGER_STATE): TextSelector(
                     TextSelectorConfig(type="text")

--- a/custom_components/ha_daily_counter/counter.py
+++ b/custom_components/ha_daily_counter/counter.py
@@ -100,8 +100,8 @@ class HADailyCounterEntity(SensorEntity, RestoreEntity):
         _LOGGER.debug("Next reset for '%s' scheduled at %s", self._name, next_reset)
 
     def _get_next_reset_time(self) -> datetime:
-        """Calculate the next reset time at 00:00 UTC."""
-        now = dt_util.utcnow()
+        """Calculate the next reset time at 00:00 local time."""
+        now = dt_util.now()  # ← Local time
         next_reset: datetime = now.replace(hour=0, minute=0, second=0, microsecond=0)
         if next_reset <= now:
             next_reset += timedelta(days=1)

--- a/custom_components/ha_daily_counter/counter.py
+++ b/custom_components/ha_daily_counter/counter.py
@@ -2,12 +2,13 @@ import logging
 from datetime import datetime, timedelta
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.core import callback, HomeAssistant
-from homeassistant.helpers.event import async_track_state_change, async_track_point_in_utc_time
+from homeassistant.core import HomeAssistant, callback, State
+from homeassistant.helpers.event import (
+    async_track_state_change,
+    async_track_point_in_utc_time,
+)
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import dt as dt_util
-
-from .const import ATTR_TRIGGER_ENTITY, ATTR_TRIGGER_STATE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -15,22 +16,21 @@ _LOGGER = logging.getLogger(__name__)
 class HADailyCounterEntity(SensorEntity, RestoreEntity):
     """Sensor that increments when another entity hits a specific state."""
 
+    _attr_state_class = "total"
+    _attr_device_class = None
+    _attr_native_unit_of_measurement = None
+    _attr_icon = "mdi:counter"
+
     def __init__(self, hass: HomeAssistant, entry_id: str, counter_config: dict) -> None:
         self.hass = hass
         self._entry_id = entry_id
-        self._unique_id = f"{entry_id}_{counter_config['id']}"
-        self._name = counter_config["name"]
-        self._trigger_entity = counter_config["trigger_entity"]
-        self._trigger_state = counter_config["trigger_state"]
-        self._device_id = counter_config["id"]
-        self._device_name = counter_config["name"]
-        self._attr_native_value = 0
-
-        # 📈 Stats support + clean appearance
-        self._attr_state_class = "total"
-        self._attr_device_class = None
-        self._attr_native_unit_of_measurement = None
-        self._attr_icon = "mdi:counter"
+        self._unique_id: str = f"{entry_id}_{counter_config['id']}"
+        self._name: str = counter_config["name"]
+        self._trigger_entity: str = counter_config["trigger_entity"]
+        self._trigger_state: str = counter_config["trigger_state"]
+        self._device_id: str = counter_config["id"]
+        self._device_name: str = counter_config["name"]
+        self._attr_native_value: int = 0
 
     @property
     def unique_id(self) -> str:
@@ -59,7 +59,6 @@ class HADailyCounterEntity(SensorEntity, RestoreEntity):
             self._attr_native_value = int(last_state.state)
             _LOGGER.debug("Restored state for %s: %s", self._name, self._attr_native_value)
 
-        # Listen for state change
         self.async_on_remove(
             async_track_state_change(
                 self.hass,
@@ -68,14 +67,18 @@ class HADailyCounterEntity(SensorEntity, RestoreEntity):
             )
         )
 
-        # Schedule daily reset at midnight
         next_reset = self._get_next_reset_time()
         self.async_on_remove(
             async_track_point_in_utc_time(self.hass, self._reset_counter, next_reset)
         )
 
     @callback
-    def _handle_trigger_state_change(self, entity_id, old_state, new_state) -> None:
+    def _handle_trigger_state_change(
+        self,
+        entity_id: str,
+        old_state: State | None,
+        new_state: State | None,
+    ) -> None:
         """Handle a trigger state change."""
         if new_state and new_state.state == self._trigger_state:
             self._attr_native_value += 1
@@ -89,7 +92,6 @@ class HADailyCounterEntity(SensorEntity, RestoreEntity):
         self.async_write_ha_state()
         _LOGGER.debug("Counter '%s' reset to 0 at scheduled hour", self._name)
 
-        # Reschedule next reset
         next_reset = self._get_next_reset_time()
         async_track_point_in_utc_time(self.hass, self._reset_counter, next_reset)
 

--- a/custom_components/ha_daily_counter/counter.py
+++ b/custom_components/ha_daily_counter/counter.py
@@ -98,7 +98,7 @@ class HADailyCounterEntity(SensorEntity, RestoreEntity):
     def _get_next_reset_time(self) -> datetime:
         """Calculate the next reset time at 00:00 UTC."""
         now = dt_util.utcnow()
-        next_reset = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        next_reset: datetime = now.replace(hour=0, minute=0, second=0, microsecond=0)
         if next_reset <= now:
             next_reset += timedelta(days=1)
         return next_reset

--- a/custom_components/ha_daily_counter/counter.py
+++ b/custom_components/ha_daily_counter/counter.py
@@ -1,13 +1,11 @@
 import logging
 from datetime import datetime, timedelta
 
-from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
-from homeassistant.core import callback, HomeAssistant
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.core import callback, HomeAssistant, State
 from homeassistant.helpers.event import async_track_state_change, async_track_point_in_utc_time
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import dt as dt_util
-
-from .const import CONF_RESET_HOUR
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -16,20 +14,15 @@ class HADailyCounterEntity(SensorEntity, RestoreEntity):
     """Sensor that increments when another entity hits a specific state."""
 
     def __init__(self, hass: HomeAssistant, entry_id: str, counter_config: dict) -> None:
-        self.hass = hass
-        self._entry_id = entry_id
-        self._unique_id = f"{entry_id}_{counter_config['id']}"
-        self._name = counter_config["name"]
-        self._trigger_entity = counter_config["trigger_entity"]
-        self._trigger_state = counter_config["trigger_state"]
-        self._device_id = counter_config["id"]
-        self._device_name = counter_config["name"]
-        self._reset_hour = counter_config.get(CONF_RESET_HOUR, 0)
-
-        self._attr_native_value = 0
-        self._attr_device_class = SensorDeviceClass.COUNT
-        self._attr_state_class = SensorStateClass.TOTAL_INCREASING
-        self._attr_native_unit_of_measurement = "events"
+        self.hass: HomeAssistant = hass
+        self._entry_id: str = entry_id
+        self._unique_id: str = f"{entry_id}_{counter_config['id']}"
+        self._name: str = counter_config["name"]
+        self._trigger_entity: str = counter_config["trigger_entity"]
+        self._trigger_state: str = counter_config["trigger_state"]
+        self._device_id: str = counter_config["id"]
+        self._device_name: str = counter_config["name"]
+        self._attr_native_value: int = 0
 
     @property
     def unique_id(self) -> str:
@@ -52,13 +45,17 @@ class HADailyCounterEntity(SensorEntity, RestoreEntity):
     def native_value(self) -> int:
         return self._attr_native_value
 
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        return None
+
     async def async_added_to_hass(self) -> None:
         """Restore state, set up trigger listener and reset timer."""
-        if (last_state := await self.async_get_last_state()) and last_state.state.isdigit():
+        last_state = await self.async_get_last_state()
+        if last_state and last_state.state.isdigit():
             self._attr_native_value = int(last_state.state)
             _LOGGER.debug("Restored state for %s: %s", self._name, self._attr_native_value)
 
-        # Listen for state change
         self.async_on_remove(
             async_track_state_change(
                 self.hass,
@@ -67,14 +64,18 @@ class HADailyCounterEntity(SensorEntity, RestoreEntity):
             )
         )
 
-        # Schedule daily reset at the configured hour
-        next_reset = self._get_next_reset_time()
+        next_reset: datetime = self._get_next_reset_time()
         self.async_on_remove(
             async_track_point_in_utc_time(self.hass, self._reset_counter, next_reset)
         )
 
     @callback
-    def _handle_trigger_state_change(self, entity_id, old_state, new_state) -> None:
+    def _handle_trigger_state_change(
+        self,
+        entity_id: str,
+        old_state: State | None,
+        new_state: State | None,
+    ) -> None:
         """Handle a trigger state change."""
         if new_state and new_state.state == self._trigger_state:
             self._attr_native_value += 1
@@ -88,14 +89,13 @@ class HADailyCounterEntity(SensorEntity, RestoreEntity):
         self.async_write_ha_state()
         _LOGGER.debug("Counter '%s' reset to 0 at scheduled hour", self._name)
 
-        # Reschedule next reset
-        next_reset = self._get_next_reset_time()
+        next_reset: datetime = self._get_next_reset_time()
         async_track_point_in_utc_time(self.hass, self._reset_counter, next_reset)
 
     def _get_next_reset_time(self) -> datetime:
-        """Calculate the next reset time based on reset_hour."""
-        now = dt_util.utcnow()
-        next_reset = now.replace(hour=self._reset_hour, minute=0, second=0, microsecond=0)
+        """Calculate the next reset time at 00:00 UTC."""
+        now: datetime = dt_util.utcnow()
+        next_reset: datetime = now.replace(hour=0, minute=0, second=0, microsecond=0)
         if next_reset <= now:
             next_reset += timedelta(days=1)
         return next_reset

--- a/custom_components/ha_daily_counter/counter.py
+++ b/custom_components/ha_daily_counter/counter.py
@@ -92,8 +92,12 @@ class HADailyCounterEntity(SensorEntity, RestoreEntity):
         self.async_write_ha_state()
         _LOGGER.debug("Counter '%s' reset to 0 at scheduled hour", self._name)
 
+        # 🛠️ FIX: Re-schedule the reset properly using `async_on_remove`
         next_reset = self._get_next_reset_time()
-        async_track_point_in_utc_time(self.hass, self._reset_counter, next_reset)
+        self.async_on_remove(
+            async_track_point_in_utc_time(self.hass, self._reset_counter, next_reset)
+        )
+        _LOGGER.debug("Next reset for '%s' scheduled at %s", self._name, next_reset)
 
     def _get_next_reset_time(self) -> datetime:
         """Calculate the next reset time at 00:00 UTC."""

--- a/custom_components/ha_daily_counter/counter.py
+++ b/custom_components/ha_daily_counter/counter.py
@@ -1,14 +1,13 @@
 import logging
 from datetime import datetime, timedelta
 
-from homeassistant.components.sensor import SensorEntity
-from homeassistant.core import callback, HomeAssistant, State
-from homeassistant.helpers.event import (
-    async_track_state_change,
-    async_track_point_in_utc_time,
-)
+from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
+from homeassistant.core import callback, HomeAssistant
+from homeassistant.helpers.event import async_track_state_change, async_track_point_in_utc_time
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import dt as dt_util
+
+from .const import CONF_RESET_HOUR
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,12 +19,17 @@ class HADailyCounterEntity(SensorEntity, RestoreEntity):
         self.hass = hass
         self._entry_id = entry_id
         self._unique_id = f"{entry_id}_{counter_config['id']}"
-        self._name: str = counter_config["name"]
+        self._name = counter_config["name"]
         self._trigger_entity = counter_config["trigger_entity"]
         self._trigger_state = counter_config["trigger_state"]
         self._device_id = counter_config["id"]
-        self._device_name: str = counter_config["name"]
+        self._device_name = counter_config["name"]
+        self._reset_hour = counter_config.get(CONF_RESET_HOUR, 0)
+
         self._attr_native_value = 0
+        self._attr_device_class = SensorDeviceClass.COUNT
+        self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+        self._attr_native_unit_of_measurement = "events"
 
     @property
     def unique_id(self) -> str:
@@ -48,10 +52,6 @@ class HADailyCounterEntity(SensorEntity, RestoreEntity):
     def native_value(self) -> int:
         return self._attr_native_value
 
-    @property
-    def native_unit_of_measurement(self) -> str | None:
-        return None
-
     async def async_added_to_hass(self) -> None:
         """Restore state, set up trigger listener and reset timer."""
         if (last_state := await self.async_get_last_state()) and last_state.state.isdigit():
@@ -67,16 +67,14 @@ class HADailyCounterEntity(SensorEntity, RestoreEntity):
             )
         )
 
-        # Schedule daily reset at midnight UTC
+        # Schedule daily reset at the configured hour
         next_reset = self._get_next_reset_time()
         self.async_on_remove(
             async_track_point_in_utc_time(self.hass, self._reset_counter, next_reset)
         )
 
     @callback
-    def _handle_trigger_state_change(
-        self, entity_id: str, old_state: State | None, new_state: State | None
-    ) -> None:
+    def _handle_trigger_state_change(self, entity_id, old_state, new_state) -> None:
         """Handle a trigger state change."""
         if new_state and new_state.state == self._trigger_state:
             self._attr_native_value += 1
@@ -88,16 +86,16 @@ class HADailyCounterEntity(SensorEntity, RestoreEntity):
         """Reset the counter to 0 and reschedule the next reset."""
         self._attr_native_value = 0
         self.async_write_ha_state()
-        _LOGGER.debug("Counter '%s' reset to 0 at midnight", self._name)
+        _LOGGER.debug("Counter '%s' reset to 0 at scheduled hour", self._name)
 
         # Reschedule next reset
         next_reset = self._get_next_reset_time()
         async_track_point_in_utc_time(self.hass, self._reset_counter, next_reset)
 
     def _get_next_reset_time(self) -> datetime:
-        """Calculate the next reset time at 00:00 UTC."""
+        """Calculate the next reset time based on reset_hour."""
         now = dt_util.utcnow()
-        next_reset: datetime = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        next_reset = now.replace(hour=self._reset_hour, minute=0, second=0, microsecond=0)
         if next_reset <= now:
             next_reset += timedelta(days=1)
         return next_reset

--- a/custom_components/ha_daily_counter/manifest.json
+++ b/custom_components/ha_daily_counter/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://github.com/Geek-MD/HA_Daily_Counter",
   "iot_class": "local_push",
   "requirements": [],
-  "version": "1.1.7"
+  "version": "1.1.8"
 }

--- a/custom_components/ha_daily_counter/manifest.json
+++ b/custom_components/ha_daily_counter/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://github.com/Geek-MD/HA_Daily_Counter",
   "iot_class": "local_push",
   "requirements": [],
-  "version": "1.1.8"
+  "version": "1.1.9"
 }

--- a/custom_components/ha_daily_counter/manifest.json
+++ b/custom_components/ha_daily_counter/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://github.com/Geek-MD/HA_Daily_Counter",
   "iot_class": "local_push",
   "requirements": [],
-  "version": "1.1.9"
+  "version": "1.1.10"
 }

--- a/custom_components/ha_daily_counter/strings.json
+++ b/custom_components/ha_daily_counter/strings.json
@@ -10,6 +10,13 @@
           "trigger_state": "Trigger State"
         }
       },
+      "trigger_state": {
+        "title": "Trigger State",
+        "description": "Enter the state that will increment the counter (e.g., 'on', 'open', 'home').",
+        "data": {
+          "trigger_state": "State to monitor"
+        }
+      },
       "done": {
         "title": "Counter Created",
         "description": "The counter {name} has been added successfully."

--- a/hacs.json
+++ b/hacs.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/Geek-MD/HA_Daily_Counter",
   "homeassistant": "2024.6.0",
   "iot_class": "local_push",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "category": "integration"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/Geek-MD/HA_Daily_Counter",
   "homeassistant": "2024.6.0",
   "iot_class": "local_push",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "category": "integration"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/Geek-MD/HA_Daily_Counter",
   "homeassistant": "2024.6.0",
   "iot_class": "local_push",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "category": "integration"
 }


### PR DESCRIPTION
### Changelog

- 🕒 Fixed counter reset time:
  - Counters now reset at **00:00 local time** instead of **00:00 UTC**, ensuring correct daily tracking behavior based on the user's timezone.

- 🔄 Internal improvements:
  - Preserved full compatibility with previous configuration structure.
  - No changes required from the user side — the fix applies automatically after update.

This patch ensures accurate daily resets in environments using local time.